### PR TITLE
fixed typo for coveragerc

### DIFF
--- a/{{cookiecutter.repo_name}}/.coveragerc
+++ b/{{cookiecutter.repo_name}}/.coveragerc
@@ -1,5 +1,5 @@
 [run]
-source = {{cookiecutter.project_name}}
+source = {{cookiecutter.repo_name}}
 
 [report]
 exclude_lines =


### PR DESCRIPTION
I had to do this change to run the following command from the blog post without problem: pytest --cov --cov-fail-under=100