### PR TITLE
Don't pass filenames to pytest

### DIFF
--- a/{{cookiecutter.repo_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.repo_name}}/.pre-commit-config.yaml
@@ -38,6 +38,7 @@ repos:
     language: system
     entry: pipenv run pytest
     types: [python]
+    pass_filenames: false
 
   - id: pytest-cov
     name: pytest


### PR DESCRIPTION
Passing filenames to pipenv run pytest sometimes causes the test collection to fail.

See https://github.com/pre-commit/pre-commit/issues/737
